### PR TITLE
resolve names when showing session

### DIFF
--- a/include/nat64/usr/session.h
+++ b/include/nat64/usr/session.h
@@ -3,6 +3,9 @@
 
 #include <stdbool.h>
 
+struct session_config {
+	bool numeric_hostname;
+};
 
 int session_display(bool use_tcp, bool use_udp, bool use_icmp);
 int session_count(bool use_tcp, bool use_udp, bool use_icmp);

--- a/usr/src/jool.c
+++ b/usr/src/jool.c
@@ -59,6 +59,11 @@ struct arguments {
 };
 
 /**
+ * configuration for showing session
+ */
+struct session_config session_config;
+
+/**
  * The flags the user can write as program parameters.
  */
 enum argp_flags {
@@ -85,6 +90,7 @@ enum argp_flags {
 	ARGP_TCP = 't',
 	ARGP_UDP = 'u',
 	ARGP_ICMP = 'i',
+	ARGP_NUMERIC_HOSTNAME = 'n',
 	/*
 	ARGP_STATIC = 2000,
 	ARGP_DYNAMIC = 2001,
@@ -183,6 +189,7 @@ static struct argp_option options[] =
 	{ "icmp",		ARGP_ICMP,		NULL, 0, "Operate on the ICMP session table." },
 	{ "tcp",		ARGP_TCP,		NULL, 0, "Operate on the TCP session table." },
 	{ "udp",		ARGP_UDP,		NULL, 0, "Operate on the UDP session table." },
+	{ "numeric",		ARGP_NUMERIC_HOSTNAME,	NULL, 0, "don't resolve names." },
 	/*
 	{ "static",		ARGP_STATIC,	NULL, 0,
 			"Filter out entries created dynamically (by incoming connections from IPv6 networks). "
@@ -287,6 +294,9 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 		break;
 	case ARGP_ICMP:
 		arguments->icmp = true;
+		break;
+	case ARGP_NUMERIC_HOSTNAME:
+		session_config.numeric_hostname = true;
 		break;
 
 	case ARGP_ADDRESS:


### PR DESCRIPTION
This is a patch which resolves names when jool shows the sessions.
I want to know names for easy to understand a situation.
Its default is resolving host. It may be controversial but I followed the behavior of netstat, for example.
