### PR TITLE
build failed in Linux 3.13

### DIFF
--- a/mod/fragment_db.c
+++ b/mod/fragment_db.c
@@ -2,6 +2,7 @@
 #include "nat64/comm/constants.h"
 #include "nat64/mod/random.h"
 
+#include <linux/version.h>
 
 #define INFINITY 60000
 
@@ -138,6 +139,19 @@ static unsigned int ipqhashfn(__be16 id, __be32 saddr, __be32 daddr, u8 prot)
 {
 	return jhash_3words((__force u32)id << 16 | prot, (__force u32)saddr, (__force u32)daddr, rnd);
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
+/**
+ * Hash function for IPv6 keys from reassembly.c
+ */
+static unsigned int inet6_hash_frag(__be32 id, const struct in6_addr *saddr,
+		const struct in6_addr *daddr, u32 rnd)
+{
+	u32 c;
+	c = jhash_3words(ipv6_addr_hash(saddr), ipv6_addr_hash(daddr), (__force u32)id, rnd);
+	return c & (INETFRAGS_HASHSZ - 1);
+}
+#endif
 
 /**
  * As specified above, the database is (mostly) a hash table. This is one of two functions used


### PR DESCRIPTION
build failed in Linux 3.13 because inet6_hash_frag of net/ipv6/reassembly.c has been static since linux 3.13.

```
$ make
make -C /lib/modules/3.13-1-amd64/build M=$PWD;
make[1]: Entering directory `/usr/src/linux-headers-3.13-1-amd64'
  CC [M]  /home/tadokoro/src/NAT64/mod/fragment_db.o
/home/tadokoro/src/NAT64/mod/fragment_db.c: In function 'hash_function':
/home/tadokoro/src/NAT64/mod/fragment_db.c:156:3: error: implicit declaration of function 'inet6_hash_frag' [-Werror=implicit-function-declaration]
   result = inet6_hash_frag(key->ipv6.identification, &key->ipv6.src_addr,
   ^
cc1: some warnings being treated as errors
make[4]: *** [/home/tadokoro/src/NAT64/mod/fragment_db.o] Error 1
make[3]: *** [_module_/home/tadokoro/src/NAT64/mod] Error 2
make[2]: *** [sub-make] Error 2
make[1]: *** [all] Error 2
make[1]: Leaving directory `/usr/src/linux-headers-3.13-1-amd64'
make: *** [all] Error 2
```

I copied the code from reassembly.c.
