### PR TITLE
Minor typo fix in manpage

### DIFF
--- a/usr/man/jool.8
+++ b/usr/man/jool.8
@@ -1,5 +1,5 @@
-./" Manpage for jool's userspace app.
-./" Report bugs to jool@nic.mx.
+.\" Manpage for jool's userspace app.
+.\" Report bugs to jool@nic.mx.
 
 .TH jool 8 2014-01-29 v3.1.0 "Jool's Userspace Application"
 


### PR DESCRIPTION
Just a minor typo fix. It was causing warning in lintian.
