### PR TITLE
pkg-config also needed?

### DIFF
--- a/en/install-usr.md
+++ b/en/install-usr.md
@@ -27,10 +27,10 @@ This document explains how to obtain the binaries of the userspace application.
 
 ## Requirements
 
-### libnl-genl-3
+### libnl-genl-3 and pkg-config
 
 {% highlight bash %}
-# apt-get install libnl-genl-3-dev
+# apt-get install libnl-genl-3-dev pkg-config
 {% endhighlight %}
 
 ### Autoconf


### PR DESCRIPTION
On a brand new Ubuntu 16.04.1 LTS xenial:

```
...
checking for pkg-config... no
checking for LIBNLGENL3... no
configure: error: in `/root/Jool-3.5.0/usr':
configure: error: The pkg-config script could not be found or is too old.  Make sure it
is in your PATH or set the PKG_CONFIG environment variable to the full
path to pkg-config.

Alternatively, you may set the environment variables LIBNLGENL3_CFLAGS
and LIBNLGENL3_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.

To get pkg-config, see <http://pkg-config.freedesktop.org/>.
See `config.log' for more details
```

After I installed pkg-config (`# apt-get install pkg-config`)...

```
...
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking for LIBNLGENL3... yes
...
```