### PR TITLE
Added documentation that pkg-config is also needed

### DIFF
--- a/usr/README
+++ b/usr/README
@@ -9,9 +9,9 @@ If you're not using git, install using `./configure && make && make install` as
 the INSTALL file says.
 
 The configure script will typically trip while looking for the Netlink
-dependency. If you're using Ubuntu, run `apt-get install libnl-3-dev` to fix
-that. Alternatively or otherwise, get it from
-http://www.infradead.org/~tgr/libnl/.
+or the pkg-config dependency. If you're using Ubuntu, run
+`apt install libnl-3-dev pkg-config` to fix that. Alternatively or otherwise,
+get Netlink from http://www.infradead.org/~tgr/libnl/.
 
 If you cloned the code using git, keep in mind that we do not upload the
 autotools generated files to the repository, so you have two options:


### PR DESCRIPTION
If pkg-config isn't installed, then the configure script can't find the netlink dependency. That confused me since i did have the latest version of nl installed.

the error message looks like this:

checking for LIBNLGENL3... no
configure: error: in `/root/jool/Jool-3.5.2/usr':
configure: error: The pkg-config script could not be found or is too old.  Make sure it
is in your PATH or set the PKG_CONFIG environment variable to the full
path to pkg-config.

Alternatively, you may set the environment variables LIBNLGENL3_CFLAGS
and LIBNLGENL3_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.