### PR TITLE
Adding changes required to compile and run Jool on Vyos

### DIFF
--- a/include/nat64/mod/common/address.h
+++ b/include/nat64/mod/common/address.h
@@ -1,6 +1,15 @@
 #ifndef _JOOL_MOD_ADDRESS_H
 #define _JOOL_MOD_ADDRESS_H
 
+#include <linux/version.h> // linux version code
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0)
+#if LINUX_VERSION_CODE > KERNEL_VERSION(4, 4, 0)
+
+#include <uapi/linux/pkt_cls.h>
+
+#endif
+#endif
+
 #include <linux/string.h>
 #include <net/ipv6.h>
 #include "nat64/common/types.h"

--- a/include/nat64/mod/common/ipv6_hdr_iterator.h
+++ b/include/nat64/mod/common/ipv6_hdr_iterator.h
@@ -10,6 +10,15 @@
  * because early validation ensures all headers can be pulled (see pskb_may_pull()).
  */
 
+#include <linux/version.h> // linux version code
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0)
+#if LINUX_VERSION_CODE > KERNEL_VERSION(4, 4, 0)
+
+#include <uapi/linux/pkt_cls.h>
+
+#endif
+#endif
+
 #include <linux/types.h>
 #include <linux/ipv6.h>
 

--- a/include/nat64/mod/common/packet.h
+++ b/include/nat64/mod/common/packet.h
@@ -65,6 +65,15 @@
  * @see https://github.com/NICMx/Jool/wiki/nf_defrag_ipv4-and-nf_defrag_ipv6
  */
 
+#include <linux/version.h> // linux version code
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0)
+#if LINUX_VERSION_CODE > KERNEL_VERSION(4, 4, 0)
+
+#include <uapi/linux/pkt_cls.h>
+
+#endif
+#endif
+
 #include <linux/skbuff.h>
 #include <net/ip.h>
 #include <net/ipv6.h>

--- a/include/nat64/mod/stateful/pool4/db.h
+++ b/include/nat64/mod/stateful/pool4/db.h
@@ -7,6 +7,15 @@
  * which packets should be translated.
  */
 
+#include <linux/version.h> // linux version code
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0)
+#if LINUX_VERSION_CODE > KERNEL_VERSION(4, 4, 0)
+
+#include <uapi/linux/pkt_cls.h>
+
+#endif
+#endif
+
 #include <linux/net.h>
 #include "nat64/mod/common/types.h"
 #include "nat64/mod/common/config.h"

--- a/mod/common/config.c
+++ b/mod/common/config.c
@@ -1,5 +1,14 @@
 #include "nat64/mod/common/config.h"
 
+#include <linux/version.h>  // linux version code
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0)
+#if LINUX_VERSION_CODE > KERNEL_VERSION(4, 4, 0)
+
+#include <uapi/linux/pkt_cls.h>
+
+#endif
+#endif
+
 #include <linux/ipv6.h>
 #include <linux/jiffies.h>
 #include "nat64/common/config.h"

--- a/mod/common/pool6.c
+++ b/mod/common/pool6.c
@@ -1,5 +1,14 @@
 #include "nat64/mod/common/pool6.h"
 
+#include <linux/version.h> // linux version code
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0)
+#if LINUX_VERSION_CODE > KERNEL_VERSION(4, 4, 0)
+
+#include <uapi/linux/pkt_cls.h>
+
+#endif
+#endif
+
 #include <net/ipv6.h>
 #include "nat64/common/constants.h"
 #include "nat64/common/str_utils.h"


### PR DESCRIPTION
The kernel version used by VyOS has a problem with duplicated header files, with different content in the different versions of some files. This has as consequence that it not possible to compile Jool on VyOS.

The included changes solve the problem of the files with reduced functionality using explicitly the right ones. This enables the compilation of Jool on VyOS, and now it is possible to run it on VyOS. 