### PR TITLE
Make src/usr/iptables/Makefile respect $DESTDIR

### DIFF
--- a/src/usr/iptables/Makefile
+++ b/src/usr/iptables/Makefile
@@ -5,6 +5,7 @@ all:
 	make libxt_JOOL_SIIT.so;
 	make libxt_JOOL.so;
 install:
+	mkdir -p ${DESTDIR}${XTABLES_SO_DIR}
 	cp *.so ${DESTDIR}${XTABLES_SO_DIR}
 uninstall:
 	rm -f ${DESTDIR}${XTABLES_SO_DIR}/libxt_JOOL_SIIT.so

--- a/src/usr/iptables/Makefile
+++ b/src/usr/iptables/Makefile
@@ -5,10 +5,10 @@ all:
 	make libxt_JOOL_SIIT.so;
 	make libxt_JOOL.so;
 install:
-	cp *.so ${XTABLES_SO_DIR}
+	cp *.so ${DESTDIR}${XTABLES_SO_DIR}
 uninstall:
-	rm -f ${XTABLES_SO_DIR}/libxt_JOOL_SIIT.so
-	rm -f ${XTABLES_SO_DIR}/libxt_JOOL.so
+	rm -f ${DESTDIR}${XTABLES_SO_DIR}/libxt_JOOL_SIIT.so
+	rm -f ${DESTDIR}${XTABLES_SO_DIR}/libxt_JOOL.so
 lib%.so: lib%.o
 	gcc -shared -fPIC -o $@ $^;
 lib%.o: lib%.c


### PR DESCRIPTION
Package build scripts often set $DESTDIR in the 'make install' command line to set an alternate destination prefix.

This patch prefixes $DESTDIR to the install destination for the xtables modules.

The other userspace makefiles are generated by automake and so already have this.