### PR TITLE
follow iptables rule option format convention

### DIFF
--- a/src/usr/iptables/common.c
+++ b/src/usr/iptables/common.c
@@ -78,7 +78,7 @@ static void jool_tg_print(const void *ip, const struct xt_entry_target *target,
 		int numeric)
 {
 	struct target_info *info = (struct target_info *)target->data;
-	printf(" instance: %s", info->iname);
+	printf(" instance:%s", info->iname);
 }
 
 /**


### PR DESCRIPTION
A tiny patch to enhance https://github.com/NICMx/Jool/pull/299.

According to convention of standard iptables extensions, there shouldn't be space
between rule option name and value.