### PR TITLE
add build dependency "libtool" for build from git repository

### DIFF
--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -198,12 +198,12 @@ If you're going to clone the git repository, you need git and the autotools:
 
 <!-- Ubuntu -->
 {% highlight bash %}
-user@T:~# apt install git autoconf
+user@T:~# apt install git autoconf libtool
 {% endhighlight %}
 
 <!-- CentOS -->
 {% highlight bash %}
-user@T:~# yum install git automake
+user@T:~# yum install git automake libtool
 {% endhighlight %}
 
 And if you don't, you will need a `.tar.gz` extraction tool:


### PR DESCRIPTION
Without libtool, `autogen.sh` fails:

```
$ ./autogen.sh 
aclocal: installing 'm4/pkg.m4' from '/usr/share/aclocal/pkg.m4'
configure.ac:10: installing './compile'
configure.ac:7: installing './install-sh'
configure.ac:7: installing './missing'
src/usr/argp/Makefile.am:1: error: Libtool library used but 'LIBTOOL' is undefined
src/usr/argp/Makefile.am:1:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
src/usr/argp/Makefile.am:1:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
src/usr/argp/Makefile.am:1:   If 'LT_INIT' is in 'configure.ac', make sure
src/usr/argp/Makefile.am:1:   its definition is in aclocal's search path.
src/usr/argp/Makefile.am: installing './depcomp'
src/usr/nl/Makefile.am:1: error: Libtool library used but 'LIBTOOL' is undefined
src/usr/nl/Makefile.am:1:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
src/usr/nl/Makefile.am:1:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
src/usr/nl/Makefile.am:1:   If 'LT_INIT' is in 'configure.ac', make sure
src/usr/nl/Makefile.am:1:   its definition is in aclocal's search path.
src/usr/util/Makefile.am:1: error: Libtool library used but 'LIBTOOL' is undefined
src/usr/util/Makefile.am:1:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
src/usr/util/Makefile.am:1:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
src/usr/util/Makefile.am:1:   If 'LT_INIT' is in 'configure.ac', make sure
src/usr/util/Makefile.am:1:   its definition is in aclocal's search path.
autoreconf: automake failed with exit status: 1
```