### PR TITLE
Define the netlink header magic string in the preprocessor

### DIFF
--- a/src/common/config.h
+++ b/src/common/config.h
@@ -17,6 +17,9 @@
 #define JOOLNL_FAMILY "Jool"
 #define JOOLNL_MULTICAST_GRP_NAME "joold"
 
+#define JOOLNL_HDR_MAGIC "jool"
+#define JOOLNL_HDR_MAGIC_LEN 4
+
 enum joolnl_operation {
 	JNLOP_INSTANCE_FOREACH,
 	JNLOP_INSTANCE_ADD,
@@ -291,7 +294,7 @@ typedef __u8 joolnlhdr_flags; /** See JOOLNLHDR_FLAGS_* above. */
  */
 struct joolnlhdr {
 	/** Always "jool". (Without terminating character.) */
-	char magic[4];
+	char magic[JOOLNL_HDR_MAGIC_LEN];
 	/** Jool's version. */
 	__be32 version;
 

--- a/src/mod/common/joold.c
+++ b/src/mod/common/joold.c
@@ -139,10 +139,7 @@ static int allocate_joold_skb(struct xlator *jool)
 	}
 
 	memset(queue->jhdr, 0, sizeof(*queue->jhdr));
-	queue->jhdr->magic[0] = 'j';
-	queue->jhdr->magic[1] = 'o';
-	queue->jhdr->magic[2] = 'o';
-	queue->jhdr->magic[3] = 'l';
+	memmove(queue->jhdr->magic, JOOLNL_HDR_MAGIC, JOOLNL_HDR_MAGIC_LEN);
 	queue->jhdr->version = cpu_to_be32(xlat_version());
 	queue->jhdr->xt = XT_NAT64;
 	memcpy(queue->jhdr->iname, jool->iname, INAME_MAX_SIZE);

--- a/src/mod/common/nl/nl_common.c
+++ b/src/mod/common/nl/nl_common.c
@@ -19,8 +19,7 @@ struct joolnlhdr *get_jool_hdr(struct genl_info *info)
 
 static int validate_magic(struct joolnlhdr *hdr)
 {
-	if (hdr->magic[0] == 'j' && hdr->magic[1] == 'o'
-			&& hdr->magic[2] == 'o' && hdr->magic[3] == 'l')
+	if (memcmp(hdr->magic, JOOLNL_HDR_MAGIC, JOOLNL_HDR_MAGIC_LEN) == 0)
 		return 0;
 
 	log_err("Don't know what to do: The packet I just received does not follow Jool's protocol.");

--- a/src/usr/nl/core.c
+++ b/src/usr/nl/core.c
@@ -57,10 +57,7 @@ struct jool_result joolnl_alloc_msg(struct joolnl_socket *socket,
 	}
 
 	memset(hdr, 0, sizeof(*hdr));
-	hdr->magic[0] = 'j';
-	hdr->magic[1] = 'o';
-	hdr->magic[2] = 'o';
-	hdr->magic[3] = 'l';
+	memmove(hdr->magic, JOOLNL_HDR_MAGIC, JOOLNL_HDR_MAGIC_LEN);
 	hdr->version = htonl(xlat_version());
 	hdr->xt = socket->xt;
 	hdr->flags = flags;
@@ -72,8 +69,7 @@ struct jool_result joolnl_alloc_msg(struct joolnl_socket *socket,
 
 static struct jool_result validate_magic(struct joolnlhdr *hdr)
 {
-	if (hdr->magic[0] == 'j' && hdr->magic[1] == 'o'
-			&& hdr->magic[2] == 'o' && hdr->magic[3] == 'l')
+	if (memcmp(hdr->magic, JOOLNL_HDR_MAGIC, JOOLNL_HDR_MAGIC_LEN) == 0)
 		return result_success();
 
 	return result_from_error(


### PR DESCRIPTION
This is a mostly cosmetic change, based on the discussions in #340 and comments on 58bf14e. This moves the header magic so that it's defined in one place only, so that if its content or length changes in the future all consumers of the header field will be updated automatically.