### PR TITLE
DKMS: Fix RHEL kernel version checks on 9.99 / 5.17

### DIFF
--- a/src/mod/common/db/pool4/rfc6056.c
+++ b/src/mod/common/db/pool4/rfc6056.c
@@ -166,7 +166,7 @@ int rfc6056_f(struct xlation *state, unsigned int *result)
 
 	desc->tfm = shash;
 /* Linux commit: 877b5691f27a1aec0d9b53095a323e45c30069e2 */
-#if LINUX_VERSION_LOWER_THAN(5, 2, 0, 9999, 0)
+#if LINUX_VERSION_LOWER_THAN(5, 2, 0, 9, 99)
 	desc->flags = 0;
 #endif
 

--- a/src/mod/common/error_pool.c
+++ b/src/mod/common/error_pool.c
@@ -1,7 +1,7 @@
 #include "mod/common/error_pool.h"
 
 #include "mod/common/linux_version.h"
-#if LINUX_VERSION_LOWER_THAN(5, 15, 0, 9999, 0)
+#if LINUX_VERSION_LOWER_THAN(5, 15, 0, 9, 99)
 #include <stdarg.h>
 #endif
 

--- a/src/mod/common/rfc7915/4to6.c
+++ b/src/mod/common/rfc7915/4to6.c
@@ -401,7 +401,7 @@ static verdict allocate_fast(struct xlation *state, bool ignore_df,
 	}
 
 	/* https://github.com/NICMx/Jool/issues/289 */
-#if LINUX_VERSION_AT_LEAST(5, 4, 0, 9999, 0)
+#if LINUX_VERSION_AT_LEAST(5, 4, 0, 9, 99)
 	nf_reset_ct(out);
 #else
 	nf_reset(out);

--- a/src/mod/common/rfc7915/6to4.c
+++ b/src/mod/common/rfc7915/6to4.c
@@ -467,7 +467,7 @@ static verdict ttp64_alloc_skb(struct xlation *state)
 	}
 
 	/* https://github.com/NICMx/Jool/issues/289 */
-#if LINUX_VERSION_AT_LEAST(5, 4, 0, 9999, 0)
+#if LINUX_VERSION_AT_LEAST(5, 4, 0, 9, 99)
 	nf_reset_ct(out);
 #else
 	nf_reset(out);

--- a/src/mod/common/skbuff.c
+++ b/src/mod/common/skbuff.c
@@ -466,7 +466,7 @@ static void print_shinfo_fields(struct sk_buff *skb, unsigned int tabs)
 	tabs++;
 	for (f = 0; f < shinfo->nr_frags; f++) {
 		print(tabs, "%u page_offset:%u size:%u", f,
-#if LINUX_VERSION_AT_LEAST(5, 4, 0, 9999, 0)
+#if LINUX_VERSION_AT_LEAST(5, 4, 0, 9, 99)
 				skb_frag_off(&shinfo->frags[f]),
 #else
 				shinfo->frags[f].page_offset,


### PR DESCRIPTION
## Problem
See #379, I encountered a bunch of kernel module build failures on Fedora 35 with 5.17 kernels.

They are all in places where there was a placeholder 9999 specified for the `RHEL_MAJOR` in the kernel version check.

## Changes
Since at least kernel 5.16 the underlying kernel patches (e.g. the renaming of `nf_reset` to `nf_reset_ct` etc.) are also present in the Fedora 35 & 36 kernels.
However the 5.16 series did not have `RHEL_RELEASE_CODE` and other RHEL_ veriables defined for whatever reason
and the `LINUX_VERSION_AT_LEAST`/`LINUX_VERSION_LOWER_THAN` conditional helpers handled them as "stock" kernels.
This made DKMS compilation still _work_.

The 5.17 kernels however do have `RHEL_RELEASE_CODE` defined again, thus the build fails because `RHEL_MAJOR` is 9, far from 9999.

Now the version checks are updated to AT_LEAST / LOWER_THAN (a, b, c, 9, 99).

This has only been tested with Fedora 35 5.16 and 5.17 kernels. I assume that the RHEL and CENTOS distros
have the same set of backports/patches when marked as 9.99+.

x.99 seems to be the version code of the development tree before a stable RHEL x+1 drops,
so I assume that 9.0-98 did not have these patches yet.
But I find the Red Hat kernel versioning system really confusing, if someone knows more and I'm wrong please let me know.

Fixes #379 