### PR TITLE
Fix the example configuration for NAT64

### DIFF
--- a/docs/en/config-atomic.md
+++ b/docs/en/config-atomic.md
@@ -185,6 +185,10 @@ Also, `pool6` is mandatory and immutable (as normal). It must be set during inst
 			"protocol": "TCP",
 			"prefix": "192.0.2.1/32"
 		}, {
+			"protocol": "TCP",
+			"prefix": "192.0.2.1/32",
+			"port range": "80"
+		}, {
 			"mark": 0,
 			"protocol": "UDP",
 			"prefix": "192.0.2.1/32",


### PR DESCRIPTION
As I mentioned Issue #388 , Jool configuration needs an appropriate pool4 entry corresponding to BIBs.
This PR adds the pool4 entry on the example configuration.