### PR TITLE
fix: build on v6.6+ kernel

### DIFF
--- a/src/mod/common/nl/nl_common.c
+++ b/src/mod/common/nl/nl_common.c
@@ -14,7 +14,7 @@ char *get_iname(struct genl_info *info)
 
 struct joolnlhdr *get_jool_hdr(struct genl_info *info)
 {
-	return info->userhdr;
+	return (struct joolnlhdr *)((u8 *)info->genlhdr + GENL_HDRLEN);
 }
 
 static int validate_magic(struct joolnlhdr *hdr)


### PR DESCRIPTION
Commit bffcc6882a "genetlink: remove userhdr from struct genl_info" caused the build to fail since the field no longer exists.

Replace with run-time calculation of the header offset.