### PR TITLE
Support 32bit architectures too

### DIFF
--- a/src/mod/common/compat_32_64.h
+++ b/src/mod/common/compat_32_64.h
@@ -1,0 +1,5 @@
+#if defined(CONFIG_64BIT)
+#define PTR_AS_UINT_TYPE   __u64
+#else
+#define PTR_AS_UINT_TYPE   __u32
+#endif

--- a/src/mod/common/nl/instance.c
+++ b/src/mod/common/nl/instance.c
@@ -3,6 +3,7 @@
 #include "common/types.h"
 #include "mod/common/log.h"
 #include "mod/common/xlator.h"
+#include "mod/common/compat_32_64.h"
 #include "mod/common/nl/attribute.h"
 #include "mod/common/nl/nl_common.h"
 #include "mod/common/nl/nl_core.h"
@@ -37,7 +38,7 @@ static int serialize_instance(struct xlator *entry, void *arg)
 	if (!root)
 		return 1;
 
-	error = nla_put_u32(skb, JNLAIE_NS, ((__u64)entry->ns) & 0xFFFFFFFF);
+	error = nla_put_u32(skb, JNLAIE_NS, ((PTR_AS_UINT_TYPE)entry->ns) & 0xFFFFFFFF);
 	if (error)
 		goto cancel;
 	error = nla_put_u8(skb, JNLAIE_XF, xlator_flags2xf(entry->flags));

--- a/src/mod/common/skbuff.c
+++ b/src/mod/common/skbuff.c
@@ -109,9 +109,9 @@ static void print_skb_fields(struct sk_buff *skb, unsigned int tabs)
 	print(tabs, "network_header:%u", skb->network_header);
 	print(tabs, "mac_header:%u", skb->mac_header);
 	print(tabs, "head:%p", skb->head);
-	print(tabs, "data:%ld", skb->data - skb->head);
-	print(tabs, "tail:%u", skb->tail);
-	print(tabs, "end:%u", skb->end);
+	print(tabs, "data:%u", (unsigned int)(skb->data - skb->head));
+	print(tabs, "tail:%u", (unsigned int)(skb->tail));
+	print(tabs, "end:%u", (unsigned int)(skb->end));
 }
 
 static int truncated(unsigned int tabs)

--- a/src/mod/common/xlator.c
+++ b/src/mod/common/xlator.c
@@ -11,6 +11,7 @@
 #include "mod/common/kernel_hook.h"
 #include "mod/common/log.h"
 #include "mod/common/rcu.h"
+#include "mod/common/compat_32_64.h"
 #include "mod/common/wkmalloc.h"
 #include "mod/common/db/denylist4.h"
 #include "mod/common/db/eam.h"
@@ -890,7 +891,7 @@ void xlator_put(struct xlator *jool)
 static bool offset_equals(struct instance_entry_usr *offset,
 		struct jool_instance *instance)
 {
-	return (offset->ns == ((__u64)instance->jool.ns & 0xFFFFFFFF))
+	return (offset->ns == ((PTR_AS_UINT_TYPE)instance->jool.ns & 0xFFFFFFFF))
 			&& (strcmp(offset->iname, instance->jool.iname) == 0);
 }
 


### PR DESCRIPTION
Hello!

I wanted NAT64 in custom Linux routers based on ARM926EJ-S, Cortex-A8, Cortex-A72, and Cortex-A53.

The first and the second architecture is 32bit so I have added the missing support for such.