### PR TITLE
Fix compilation in v6.18

### DIFF
--- a/src/mod/common/rfc7915/6to4.c
+++ b/src/mod/common/rfc7915/6to4.c
@@ -203,7 +203,11 @@ static verdict compute_flowix64(struct xlation *state)
 	hdr6 = pkt_ip6_hdr(&state->in);
 
 	flow4->flowi4_mark = state->in.skb->mark;
+#if LINUX_VERSION_AT_LEAST(6, 18, 0, 0, 0)
+	flow4->flowi4_dscp = xlat_tos(&state->jool.globals, hdr6);
+#else
 	flow4->flowi4_tos = xlat_tos(&state->jool.globals, hdr6);
+#endif
 	flow4->flowi4_scope = RT_SCOPE_UNIVERSE;
 	flow4->flowi4_proto = xlat_proto(hdr6);
 	/*
@@ -645,7 +649,11 @@ static verdict ttp64_ipv4_external(struct xlation *state)
 
 	hdr4->version = 4;
 	hdr4->ihl = 5;
+#if LINUX_VERSION_AT_LEAST(6, 18, 0, 0, 0)
+	hdr4->tos = flow4->flowi4_dscp;
+#else
 	hdr4->tos = flow4->flowi4_tos;
+#endif
 	hdr4->tot_len = cpu_to_be16(state->out.skb->len);
 	generate_ipv4_id(state, hdr4, hdr_frag);
 	hdr4->frag_off = xlat_frag_off(hdr_frag, state);


### PR DESCRIPTION
struct flowi4.tos renamed to 'dscp' and type dscp_t in commit 1bec9d0c0046fe4e2bfb6a1c5aadcb5d56cdb0fb