### PR TITLE
Changed LINUX_VERSION_AT_LEAST param from 9999 to 9

### DIFF
--- a/src/mod/common/icmp_wrapper.c
+++ b/src/mod/common/icmp_wrapper.c
@@ -18,7 +18,7 @@ static int route4_input(struct xlator *jool, struct sk_buff *skb)
 
 	hdr = ip_hdr(skb);
 	error = ip_route_input(skb, hdr->daddr, hdr->saddr,
-#if LINUX_VERSION_AT_LEAST(6, 13, 0, 9999, 0)
+#if LINUX_VERSION_AT_LEAST(6, 13, 0, 9, 0)
 			ip4h_dscp(hdr),
 #else
 			hdr->tos,


### PR DESCRIPTION
The value 9999 in mis-interpreted when building on Rocky 9
I see this same issue was fixed other places in the code between release 4.1.15 and 4.2.0-rc3, it appearing here seems to be a regression.