### PR TITLE
stats: fix v7.2 loss of snmp_fold_field()

### DIFF
--- a/src/mod/common/stats.c
+++ b/src/mod/common/stats.c
@@ -4,6 +4,7 @@
 #include <net/ip.h>
 #include <net/snmp.h>
 #include "mod/common/wkmalloc.h"
+#include "mod/common/linux_version.h"
 
 struct jool_mib {
 	unsigned long mibs[JSTAT_COUNT];
@@ -79,8 +80,15 @@ __u64 *jstat_query(struct jool_stats *stats)
 	if (!result)
 		return NULL;
 
-	for (i = 0; i < JSTAT_COUNT; i++)
+	for (i = 0; i < JSTAT_COUNT; i++) {
+#if LINUX_VERSION_AT_LEAST(7, 2, 0, 0, 0)
+		int cpu;
+		for_each_possible_cpu(cpu)
+			result[i] += snmp_get_cpu_field(stats->mib, cpu, i);
+#else
 		result[i] = snmp_fold_field(stats->mib, i);
+#endif
+	}
 
 	return result;
 }


### PR DESCRIPTION
Since b056e7326724

"ipv4: remove obsolete EXPORT_SYMBOL() and EXPORT_SYMBOL_GPL()"

snmp_fold_field() is no longer available.

Extract its code and use directly.

Note: Unable to do run-time tests of this so far so needs some Tested-by: sign-offs.